### PR TITLE
Support opening a database in-memory

### DIFF
--- a/sqlite.js
+++ b/sqlite.js
@@ -56,7 +56,9 @@ function sqlite () {
    sqlite.prototype.connect = function(db){
    	if(typeof(db)=='string'){
    		this.file = db;
-   		if(fs.existsSync(this.file)){
+		if (!db || db === ':memory:' || db.indexOf('file::memory:') === 0) {
+			this.buffer = new Buffer(0);
+		} else if(fs.existsSync(this.file)){
    			this.buffer = fs.readFileSync(this.file);
    		}
    	}else if(typeof(db)=="object"){


### PR DESCRIPTION
See: https://www.sqlite.org/inmemorydb.html

Sqlite will create a database that exists only in memory until there is a disconnection when using `:memory:` as filename or an empty string.